### PR TITLE
Add volume mounts for LDAP account manager configuration

### DIFF
--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -19,7 +19,6 @@ for evar in [
         "TRAEFIK_LETS_ENCRYPT",
         "LDAP_ADMIN_USERS",
         "LAM_LOGIN_METHOD",
-        "LAM_PASSWORD",
         "LDAP_DOMAIN",
         "LAM_LICENSE"
     ]:

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+# dump the configuration of the Ldap account manager instance
+podman cp lam:/var/lib/ldap-account-manager/config/lam.conf ./lam-config/lam.conf
+podman cp lam:/etc/ldap-account-manager/config.cfg ./lam-config/config.cfg

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -4,3 +4,6 @@
 # Restic --files-from: https://restic.readthedocs.io/en/stable/040_backup.html#including-files
 #
 
+volumes/etc
+volumes/config
+state/lam-config

--- a/imageroot/systemd/user/lam.service
+++ b/imageroot/systemd/user/lam.service
@@ -22,6 +22,8 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/lam.pid \
     --publish 127.0.0.1:${TCP_PORT}:80 \
     --network=slirp4netns:allow_host_loopback=true \
     --add-host=accountprovider:10.0.2.2 \
+    --volume config:/var/lib/ldap-account-manager/config:Z \
+    --volume etc:/etc/ldap-account-manager/:Z \
     --env LDAP_BASE_DN=${LDAP_BASE} \
     --env LAM_LICENSE=${LAM_LICENSE} \
     ${LAM_IMAGE}

--- a/imageroot/systemd/user/lam.service
+++ b/imageroot/systemd/user/lam.service
@@ -32,6 +32,8 @@ ExecStartPost=podman cp ./lam-config/lam.conf lam:/var/lib/ldap-account-manager/
 ExecStartPost=podman exec lam chown www-data:root /var/lib/ldap-account-manager/config/lam.conf
 ExecStartPost=podman cp ./lam-config/config.cfg lam:/etc/ldap-account-manager/config.cfg
 ExecStartPost=podman exec lam chown www-data:root /etc/ldap-account-manager/config.cfg
+# fix bad symlink after clone
+ExecStartPost=podman exec lam ln -sf /etc/ldap-account-manager/config.cfg /var/lib/ldap-account-manager/config/config.cfg
 ExecStop=podman cp lam:/var/lib/ldap-account-manager/config/lam.conf ./lam-config/lam.conf
 ExecStop=podman cp lam:/etc/ldap-account-manager/config.cfg ./lam-config/config.cfg
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/lam.ctr-id -t 10


### PR DESCRIPTION
Introduce volume mounts in the service configuration to ensure proper access to LDAP account manager settings.
fix bad symbolic link with clone module
fix backup and restore
